### PR TITLE
Fix errors in NotFound and Results pages

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
 export default function NotFound() {
-  <div className="text-center">
-    <p className="text-4xl">🤷‍♂️</p>
-    <h1 className="text-2xl font-semibold">Page not found</h1>
-  </div>;
+  return (
+    <div className="text-center">
+      <p className="text-4xl">🤷‍♂️</p>
+      <h1 className="text-2xl font-semibold">Page not found</h1>
+    </div>
+  );
 }

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -35,7 +35,7 @@ export default async function Results({
     }
     return (
       <p className="text-red-500">
-        Error fetching results. Please try again later. ${message}
+        {`Error fetching results. Please try again later. ${message}`}
       </p>
     );
   }


### PR DESCRIPTION
## Summary
- correct missing return statement in `NotFound` page
- show error messages properly on the results page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683fcffe913c833081ce3475f453c34a