### PR TITLE
Fix vite vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14906,9 +14906,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/app/api/my-movies/route.ts
+++ b/src/app/api/my-movies/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import supabase from '@/lib/supabase';
 
-export async function GET(req: Request) {
+export async function GET() {
   // Get current Clerk userId (using Clerk's API)
   const { userId } = await auth();
 


### PR DESCRIPTION
## Summary
- update transitive vite dev dependency to remove security alert
- clean up unused `req` param to satisfy lint

## Testing
- `npm run lint`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_683fda322d148330b76904be2af7e5cd